### PR TITLE
fix: component foldername spelling mistake

### DIFF
--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import Navbar from '../compments/navbar/Navbar'
+import Navbar from '../components/navbar/Navbar'
 
 function Dashboard() {
   return <div>Dashboard</div>

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import Navbar from '../compments/navbar/Navbar'
+import Navbar from '../components/navbar/Navbar'
 import { Link } from 'react-router-dom'
 
 function Home() {

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -1,5 +1,5 @@
 import { useState, React } from 'react'
-import Navbar from '../compments/navbar/Navbar'
+import Navbar from '../components/navbar/Navbar'
 import { Link } from 'react-router-dom'
 function LoginPage() {
   const [email, setEmail] = useState('')
@@ -51,7 +51,8 @@ function LoginPage() {
               ></input>
 
               <p className="mt-5">
-                Don't have an account? <Link to="/signup">Create account</Link>
+                Don&apos;t have an account?{' '}
+                <Link to="/signup">Create account</Link>
               </p>
 
               <button

--- a/frontend/src/pages/Pages.jsx
+++ b/frontend/src/pages/Pages.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import Home from './Home'
-import Navbar from '../compments/navbar/Navbar'
+import Navbar from '../components/navbar/Navbar'
 import LoginPage from './LoginPage'
 
 let logedIn = false

--- a/frontend/src/pages/Profile.jsx
+++ b/frontend/src/pages/Profile.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import Navbar from '../compments/navbar/Navbar'
+import Navbar from '../components/navbar/Navbar'
 import { Link } from 'react-router-dom'
 
 function ProfilePage() {

--- a/frontend/src/pages/ProfileCreation.jsx
+++ b/frontend/src/pages/ProfileCreation.jsx
@@ -1,5 +1,5 @@
 import { useState, React } from 'react'
-import Navbar from '../compments/navbar/Navbar'
+import Navbar from '../components/navbar/Navbar'
 import { Link } from 'react-router-dom'
 
 function ProfileCreation() {

--- a/frontend/src/pages/SignUpPage.jsx
+++ b/frontend/src/pages/SignUpPage.jsx
@@ -1,5 +1,5 @@
 import { useState, React } from 'react'
-import Navbar from '../compments/navbar/Navbar'
+import Navbar from '../components/navbar/Navbar'
 import { Link, useNavigate } from 'react-router-dom'
 
 function LoginPage() {


### PR DESCRIPTION
components folder was initially misspelled as "compments"
the folder was renamed but the imported packages still referenced the "compments" instead of "components"

Co-authored-by: vskvj3 <92223768+vskvj3@users.noreply.github.com>
Co-authored-by: Abhishek Raymond <abhishekraymond007@gmail.com>